### PR TITLE
feat: add PyPI publish workflow and build tooling

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,31 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: clean build publish-test publish
+
+clean:
+	rm -rf dist/ build/ *.egg-info
+
+build: clean
+	python -m build
+
+publish-test: build
+	python -m twine upload --repository testpypi dist/*
+
+publish: build
+	python -m twine upload dist/*

--- a/cloud_billing/__init__.py
+++ b/cloud_billing/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.0"
+__version__ = "0.1.25"
 
 from .alibaba_cloud import AlibabaCloudClient
 from .aws_cloud import AWSCloudClient

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cloud-billing"
-version = "0.1.0"
+version = "0.1.25"
 description = "Multi-cloud billing data retrieval SDK for Alibaba Cloud, AWS, Azure, and Huawei Cloud with unified API"
 authors = [
     {name = "Kai Yang", email = "kaiyang939325@gmail.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,23 @@
 [project]
 name = "cloud-billing"
 version = "0.1.0"
-description = "A package to fetch billing information from Alibaba Cloud, AWS, Azure, and Huawei Cloud"
+description = "Multi-cloud billing data retrieval SDK for Alibaba Cloud, AWS, Azure, and Huawei Cloud with unified API"
 authors = [
     {name = "Kai Yang", email = "kaiyang939325@gmail.com"}
 ]
 license = "GPL-3.0-or-later"
 readme = "README.md"
 requires-python = ">=3.10"
+keywords = [
+    "cloud",
+    "billing",
+    "alibaba-cloud",
+    "aws",
+    "azure",
+    "huawei-cloud",
+    "cost-management",
+    "finops",
+]
 dependencies = [
     "aliyun-python-sdk-core>=2.16.0,<3.0.0",
     "boto3>=1.35.0,<2.0.0",
@@ -22,14 +32,21 @@ dependencies = [
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Office/Business :: Financial",
 ]
 
 [project.optional-dependencies]
-# Install with: pip install -e ".[saas]"  or  uv pip install -e ".[saas]"
+dev = [
+    "build>=1.2.0",
+    "twine>=6.0.0",
+]
 saas = [
     "fastapi>=0.117.0",
     "uvicorn>=0.34.0",
@@ -61,7 +78,7 @@ mkdocstrings-python = "^1.17.0"
 
 [tool.setuptools.packages.find]
 where = ["."]
-exclude = ["tests*", "dist*", "build*"]
+exclude = ["tests*", "dist*", "build*", "api*", "scripts*", "docs*"]
 
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]


### PR DESCRIPTION
## Summary
- 新增 `publish-pypi.yml` GitHub Actions 工作流，Release 发布时自动通过 Trusted Publishing (OIDC) 发布到 PyPI
- 新增 `Makefile`，提供 `clean` / `build` / `publish-test` / `publish` 本地构建发布命令
- 完善 `pyproject.toml` 元数据：keywords、classifiers、dev 依赖组

## Test Plan
- [x] `python -m build` 构建通过
- [x] `twine check dist/*` 检查通过
- [ ] 在 PyPI 配置 Trusted Publishing（首次发布前需前往 https://pypi.org 添加 publisher）
- [ ] 创建 GitHub Release 验证自动发布流程

🤖 Generated with [Claude Code](https://claude.com/claude-code)