### PR TITLE
chore: add Apache 2.0 license headers to all source files

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Cloud Billing SaaS — FastAPI entry point for Vercel.
 

--- a/cloud_billing/__init__.py
+++ b/cloud_billing/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 __version__ = "0.1.25"
 
 from .alibaba_cloud import AlibabaCloudClient

--- a/cloud_billing/alibaba_cloud/__init__.py
+++ b/cloud_billing/alibaba_cloud/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .client import AlibabaCloudClient
 from .utils import parse_aliyun_tag
 

--- a/cloud_billing/alibaba_cloud/client.py
+++ b/cloud_billing/alibaba_cloud/client.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 import re
 from dataclasses import dataclass

--- a/cloud_billing/alibaba_cloud/exceptions.py
+++ b/cloud_billing/alibaba_cloud/exceptions.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Dict, Optional
 
 

--- a/cloud_billing/alibaba_cloud/types.py
+++ b/cloud_billing/alibaba_cloud/types.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from enum import Enum
 from typing import List, Optional
 

--- a/cloud_billing/alibaba_cloud/utils.py
+++ b/cloud_billing/alibaba_cloud/utils.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from typing import Dict
 
 

--- a/cloud_billing/aws_cloud/__init__.py
+++ b/cloud_billing/aws_cloud/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .client import AWSCloudClient
 
 __all__ = ["AWSCloudClient"]

--- a/cloud_billing/aws_cloud/client.py
+++ b/cloud_billing/aws_cloud/client.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """AWS Cloud billing client using Cost Explorer API."""
 
 import re

--- a/cloud_billing/aws_cloud/types.py
+++ b/cloud_billing/aws_cloud/types.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Pydantic models for AWS Cost Explorer API responses."""
 
 from typing import Any, Dict, List, Optional

--- a/cloud_billing/azure_cloud/__init__.py
+++ b/cloud_billing/azure_cloud/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .client import AzureCloudClient
 
 __all__ = ["AzureCloudClient"]

--- a/cloud_billing/azure_cloud/client.py
+++ b/cloud_billing/azure_cloud/client.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import csv
 import json
 import logging

--- a/cloud_billing/azure_cloud/types.py
+++ b/cloud_billing/azure_cloud/types.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from datetime import date, datetime
 from enum import Enum
 from typing import Optional

--- a/cloud_billing/common/__init__.py
+++ b/cloud_billing/common/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/cloud_billing/common/utils.py
+++ b/cloud_billing/common/utils.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from datetime import datetime
 from typing import Union
 

--- a/cloud_billing/huawei_cloud/__init__.py
+++ b/cloud_billing/huawei_cloud/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .client import HuaweiCloudClient
 
 __all__ = ["HuaweiCloudClient"]

--- a/cloud_billing/huawei_cloud/client.py
+++ b/cloud_billing/huawei_cloud/client.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Huawei Cloud billing client using BSS API."""
 
 import re

--- a/cloud_billing/huawei_cloud/types.py
+++ b/cloud_billing/huawei_cloud/types.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Pydantic models for Huawei Cloud BSS API responses."""
 
 from typing import List, Optional

--- a/cloud_billing/kubecost/__init__.py
+++ b/cloud_billing/kubecost/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/cloud_billing/kubecost/client.py
+++ b/cloud_billing/kubecost/client.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import json
 import logging
 from datetime import datetime, timedelta

--- a/cloud_billing/kubecost/types.py
+++ b/cloud_billing/kubecost/types.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from datetime import datetime
 from decimal import Decimal
 from typing import Any, Dict, Optional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Multi-cloud billing data retrieval SDK for Alibaba Cloud, AWS, Az
 authors = [
     {name = "Kai Yang", email = "kaiyang939325@gmail.com"}
 ]
-license = "GPL-3.0-or-later"
+license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.10"
 keywords = [

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,15 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Tests package

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Pytest configuration – provide mock stubs for cloud SDKs not installed locally."""
 import sys
 import types

--- a/tests/test_alibaba_client.py
+++ b/tests/test_alibaba_client.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Unit tests for AlibabaCloudClient."""
 
 import json

--- a/tests/test_alibaba_utils.py
+++ b/tests/test_alibaba_utils.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pytest
 
 from cloud_billing.alibaba_cloud.utils import parse_aliyun_tag

--- a/tests/test_aws_client.py
+++ b/tests/test_aws_client.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Unit tests for AWSCloudClient."""
 
 from unittest.mock import MagicMock, patch

--- a/tests/test_azure_client.py
+++ b/tests/test_azure_client.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Unit tests for AzureCloudClient."""
 
 import json

--- a/tests/test_common_utils.py
+++ b/tests/test_common_utils.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Unit tests for common utilities."""
 
 from datetime import datetime

--- a/tests/test_huawei_client.py
+++ b/tests/test_huawei_client.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Unit tests for HuaweiCloudClient."""
 
 from unittest.mock import MagicMock, patch

--- a/tests/test_kubecost_client.py
+++ b/tests/test_kubecost_client.py
@@ -1,3 +1,17 @@
+# Copyright 2025 Visionary Future
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from datetime import datetime, timezone
 from decimal import Decimal
 from unittest.mock import MagicMock, patch


### PR DESCRIPTION
## Summary
- 修复 `pyproject.toml` 中 license 声明（GPL-3.0 → Apache-2.0），与 LICENSE 文件一致
- 给全部 30 个 `.py` 文件添加 Apache 2.0 版权头

## Test plan
- [x] 确认 LICENSE 文件与 pyproject.toml 许可证一致
- [x] 确认每个源文件都包含 Apache 2.0 header

🤖 Generated with [Claude Code](https://claude.com/claude-code)